### PR TITLE
Automated Daily Staging Runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -447,7 +447,7 @@ workflows:
     triggers:
       - schedule:
           # Daily at 3am UTC /  8pm MST / 8:30am IST
-          cron: "0 3 * * *"
+          cron: "45 6 * * *"
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -447,7 +447,7 @@ workflows:
     triggers:
       - schedule:
           # Daily at 3am UTC /  8pm MST / 8:30am IST
-          cron: "45 6 * * *"
+          cron: "0 3 * * *"
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -443,11 +443,11 @@ workflows:
       - handle_all_pass:
           <<: *wrapupjob
 
-  staging_tests_automated:
+  Daily_Staging_Tests:
     triggers:
       - schedule:
-          # weekly at 3am on Monday UTC / 9pm Saturday MST / 8:30am Monday IST
-          cron: "30 6 * * *"
+          # Daily at 3am UTC /  8pm MST / 8:30am IST
+          cron: "0 3 * * *"
           filters:
             branches:
               only: master


### PR DESCRIPTION
-Added automated trigger for Staging Test Runs on daily basis
-Below is the schedule of runs:

Daily at 3am UTC == Daily at 8pm MST == Daily at 8.30am IST