### PR TITLE
EL-5717 Make staging tests in sync with snapshot tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,6 +340,7 @@ jobs:
       - churros-setup
       - churros: { test_name: elements/sapc4chd }
       - churros: { test_name: elements/taleobusiness, exclude: true}
+      - churros: { test_name: elements/stripe }
       - churros-rules
 
   churros_tests_7:
@@ -347,6 +348,7 @@ jobs:
     steps:
       - churros-setup
       - churros: { test_name: elements/pardot}
+      - churros: { test_name: elements/mailchimpv3 } 
       - churros-rules
 
   churros_tests_8:
@@ -355,6 +357,7 @@ jobs:
     steps:
       - churros-setup
       - churros: { test_name: elements/salesforcemarketingcloud }
+      - churros: { test_name: elements/concur }    
       - churros-rules
   churros_tests_9:
     <<: *churros-build-setup
@@ -362,6 +365,7 @@ jobs:
     steps:
       - churros-setup
       - churros: { test_name: elements/sapc4ccrm }
+      - churros: { test_name: elements/netsuitehcv2 }
       - churros: { test_name: elements/successfactors, exclude: true }
       - churros-rules
 
@@ -372,6 +376,8 @@ jobs:
       - churros-setup
       - churros: { test_name: elements/brighttalk }
       - churros: { test_name: elements/sendgrid }
+      - churros: { test_name: elements/globalmeet }
+      - churros: { test_name: elements/autotaskhelpdesk }
       - churros-rules
   churros_tests_12:
     <<: *churros-build-setup
@@ -388,8 +394,9 @@ jobs:
       - churros: { test_name: elements/chargebee }
       - churros: { test_name: elements/kissmetrics }
       - churros: { test_name: elements/taxify }
-      - churros: { test_name: elements/sailthru, exclude: true  }
+      - churros: { test_name: elements/sailthru }
       - churros: { test_name: elements/eventmobiv1 }
+      - churros: { test_name: elements/expensify}
       - churros-rules
   # it is expected that this job only runs if all tests pass
   handle_all_pass:


### PR DESCRIPTION
Following are the changes
- Including expensify as EL-5745 is fixed (https://cl.ly/e15a8d5ed3bb)
- Including sailthru as same test was enabled in prod & it works with any issues (https://circleci.com/gh/cloud-elements/churros-sauce-production/1226)
- Including stripe, mailchimpv3, concur, netsuitehcv2, globalmeet, autotaskhelpdesk & sailthru as they are already part of snapshot test runs (https://circleci.com/workflow-run/2015d01f-55b5-46ff-8b4f-ba77200d466e, https://circleci.com/workflow-run/bcc9c6ed-95c6-46bf-a8cd-5448223de96d)