### PR TITLE
EL-7383 Fixing 1pass initialization in churros init

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,10 +88,13 @@ commands:
       - run:
           name: install 1password-cli
           command: |
-            curl -s -L -O https://raw.githubusercontent.com/cloud-elements/onepass/master/linux/op
-            chmod a+x op
-            ln -s $PWD/op /bin/op
-  
+            curl -o op https://cache.agilebits.com/dist/1P/op/pkg/v0.9.4/op_linux_amd64_v0.9.4.zip
+            unzip -o op
+            gpg --receive-keys 3FEF9748469ADBE15DA7CA80AC2D62742012EA22
+            gpg --verify op.sig op
+            ln -fs $PWD/op /bin/op
+            op --version
+
   install-node:
     steps:
       - run:


### PR DESCRIPTION
- Churros init started failing due to op cli issues
- Currently we are pulling op cli executable from repo cloud-elements/onepass
- updated sauce config to pull it from 1pass official site
- add gpg keys and op.sig
- Current version is pointing to 0.9.4